### PR TITLE
Move HSFLL configuration to DT

### DIFF
--- a/soc/arm/nordic_nrf/nrf54h/Kconfig.defconfig.nrf54h20_cpuapp
+++ b/soc/arm/nordic_nrf/nrf54h/Kconfig.defconfig.nrf54h20_cpuapp
@@ -11,14 +11,4 @@ config SOC
 config NUM_IRQS
 	default 471
 
-config SOC_TRIM_HSFLL
-	default y
-
-config FICR_HSFLL_TRIM_IDX
-	# CPUAPP operates at 320 MHz
-	default 0
-
-config HSFLL_CLOCK_MULTIPLIER
-	default 0
-
 endif # SOC_NRF54H20_ENG0_CPUAPP

--- a/soc/arm/nordic_nrf/nrf54h/Kconfig.defconfig.nrf54h20_cpurad
+++ b/soc/arm/nordic_nrf/nrf54h/Kconfig.defconfig.nrf54h20_cpurad
@@ -11,14 +11,4 @@ config SOC
 config NUM_IRQS
 	default 471
 
-config SOC_TRIM_HSFLL
-	default y
-
-config FICR_HSFLL_TRIM_IDX
-	# CPURAD operates at 256 MHz
-	default 1
-
-config HSFLL_CLOCK_MULTIPLIER
-	default 16
-
 endif # SOC_NRF54H20_ENG0_CPURAD

--- a/soc/arm/nordic_nrf/nrf54h/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf54h/Kconfig.series
@@ -15,31 +15,3 @@ config SOC_SERIES_NRF54HX
 	select HAS_SEGGER_RTT if ZEPHYR_SEGGER_MODULE
 	help
 	  Enable support for nRF54H MCU series
-
-if SOC_SERIES_NRF54HX
-
-config SOC_TRIM_HSFLL
-	bool
-	help
-	  SoC HSFLL hardware should be trimmed for accurate clock speeds.
-
-config FICR_HSFLL_TRIM_IDX
-	int
-	depends on SOC_TRIM_HSFLL
-	help
-	  Table 1 of the FICR chapter in the Product Specification describes
-	  which index of the COARSE and FINE trims must be applied to the domain
-	  HSFLL for a given frequency.
-
-	  Refer to nRF54H20 Product Specification > Product configuration >
-	  Information configuration registers (ICR) > Peripherals > FICR
-	  for more information.
-
-config HSFLL_CLOCK_MULTIPLIER
-	int
-	depends on SOC_TRIM_HSFLL
-	help
-	  The HSFLL multiplies the frequency of the input 16 MHz clock
-	  by a value stored in CLOCKTRL.MULT register.
-
-endif # SOC_SERIES_NRF54HX

--- a/soc/arm/nordic_nrf/nrf54h/soc.c
+++ b/soc/arm/nordic_nrf/nrf54h/soc.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/cache.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -15,13 +16,15 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 #if defined(NRF_APPLICATION)
 #define HSFLL_NODE DT_NODELABEL(cpuapp_hsfll)
-#define FICR_TRIM_BLOCK NRF_FICR->TRIM.APPLICATION
 #elif defined(NRF_RADIOCORE)
 #define HSFLL_NODE DT_NODELABEL(cpurad_hsfll)
-#define FICR_TRIM_BLOCK NRF_FICR->TRIM.RADIOCORE
 #else
 #error "Unsupported SoC"
 #endif
+
+#define FICR_ADDR_GET(node_id, name)                                           \
+	DT_REG_ADDR(DT_PHANDLE_BY_NAME(node_id, nordic_ficrs, name)) +         \
+		DT_PHA_BY_NAME(node_id, nordic_ficrs, name, offset)
 
 static void power_domain_init(void)
 {
@@ -49,23 +52,22 @@ static void power_domain_init(void)
 #endif
 }
 
-#if defined(CONFIG_SOC_TRIM_HSFLL)
 static int trim_hsfll(void)
 {
 	NRF_HSFLL_Type *hsfll = (NRF_HSFLL_Type *)DT_REG_ADDR(HSFLL_NODE);
-	const nrf_hsfll_trim_t trim = {
-		.vsup = FICR_TRIM_BLOCK.HSFLL.TRIM.VSUP,
-		.coarse = FICR_TRIM_BLOCK.HSFLL.TRIM.COARSE[CONFIG_FICR_HSFLL_TRIM_IDX],
-		.fine = FICR_TRIM_BLOCK.HSFLL.TRIM.FINE[CONFIG_FICR_HSFLL_TRIM_IDX],
+	nrf_hsfll_trim_t trim = {
+		.vsup = sys_read32(FICR_ADDR_GET(HSFLL_NODE, vsup)),
+		.coarse = sys_read32(FICR_ADDR_GET(HSFLL_NODE, coarse)),
+		.fine = sys_read32(FICR_ADDR_GET(HSFLL_NODE, fine))
 	};
 
 	LOG_DBG("Trim: HSFLL VSUP: 0x%.8x", trim.vsup);
 	LOG_DBG("Trim: HSFLL COARSE: 0x%.8x", trim.coarse);
 	LOG_DBG("Trim: HSFLL FINE: 0x%.8x", trim.fine);
 
-	if (CONFIG_HSFLL_CLOCK_MULTIPLIER) {
-		nrf_hsfll_clkctrl_mult_set(hsfll, CONFIG_HSFLL_CLOCK_MULTIPLIER);
-	}
+	nrf_hsfll_clkctrl_mult_set(hsfll,
+				   DT_PROP(HSFLL_NODE, clock_frequency) /
+					   DT_PROP(DT_CLOCKS_CTLR(HSFLL_NODE), clock_frequency));
 	nrf_hsfll_trim_set(hsfll, &trim);
 
 	nrf_hsfll_task_trigger(hsfll, NRF_HSFLL_TASK_FREQ_CHANGE);
@@ -82,7 +84,6 @@ static int trim_hsfll(void)
 
 	return 0;
 }
-#endif /* CONFIG_SOC_TRIM_HSFLL */
 
 static int nordicsemi_nrf54h_init(void)
 {
@@ -92,9 +93,7 @@ static int nordicsemi_nrf54h_init(void)
 
 	power_domain_init();
 
-#if defined(CONFIG_SOC_TRIM_HSFLL)
 	trim_hsfll();
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
Note: a simple clock control driver (init only?) could also be implemented to avoid code in soc.